### PR TITLE
startTransaction requires connectorId

### DIFF
--- a/src/ChargerSimulator.ts
+++ b/src/ChargerSimulator.ts
@@ -189,6 +189,10 @@ export class ChargerSimulator {
   private transactionId = null
   private chargePoint = {
     RemoteStartTransaction: async (req) => {
+      if (!req.connectorId) {
+        req.connectorId = 1
+      }
+      
       return {
         status: this.startTransaction(req, true) ? "Accepted" : "Rejected",
         // status: "Rejected",

--- a/src/ChargerSimulator.ts
+++ b/src/ChargerSimulator.ts
@@ -16,6 +16,8 @@ export interface Config {
   centralSystemEndpoint: string
   chargerIdentity: string
   chargePointPort?: number
+
+  connectorId: number
 }
 
 const defaultConfig: Partial<Config> = {
@@ -190,7 +192,7 @@ export class ChargerSimulator {
   public chargePoint = {
     RemoteStartTransaction: async (req) => {
       if (!req.connectorId) {
-        req.connectorId = 1
+        req.connectorId = this.config.connectorId
       }
       
       return {

--- a/src/chargerSimulatorCli.ts
+++ b/src/chargerSimulatorCli.ts
@@ -33,7 +33,7 @@ const optionList = [
   },
   {
     name: "connectorId",
-    type: String,
+    type: Number,
     description: "ID of the connector to send status when pressing keys.\nDefaults to 1.",
     typeLabel: "{underline ConnectorId}",
     alias: "c",
@@ -80,6 +80,7 @@ const usageSections = [
     centralSystemEndpoint: csURL,
     chargerIdentity: chargerId,
     chargePointPort: cpPort,
+    connectorId: connectorId,
   })
   await simulator.start()
 


### PR DESCRIPTION
RemoteStartTransaction leads to StartTransaction without connectorId, crashing OCPP. Which is OK since StartTransaction connectorId is required. However it would be nice if this would work as per spec.

> The RemoteStartTransaction.req MAY contain a connector id if the transaction is to be started on a specific connector. When no connector id is provided, the Charge Point is in control of the connector selection. A Charge Point MAY reject a RemoteStartTransaction.req without a connector id.

— `ocpp-1.6.pdf`