### PR TITLE
include all ocpp statusses

### DIFF
--- a/src/chargerSimulatorCli.ts
+++ b/src/chargerSimulatorCli.ts
@@ -99,7 +99,10 @@ const usageSections = [
     p:        send Preparing status
     c:        send Charging status
     e:        send SuspendedEV status
+    v:        send SuspendedEVSE status
     f:        send Finishing status
+    r:        send Reserved status
+    n:        send Unavailable status
     x:        send Faulted status
     
     Transaction on connector ${connectorId}, tag ${idTag}
@@ -149,8 +152,11 @@ const usageSections = [
     a: () => sendStatus("Available"),
     p: () => sendStatus("Preparing"),
     c: () => sendStatus("Charging"),
+    v: () => sendStatus("SuspendedEVSE"),
     e: () => sendStatus("SuspendedEV"),
     f: () => sendStatus("Finishing"),
+    r: () => sendStatus("Reserved"),
+    n: () => sendStatus("Unavailable"),
     x: () => sendStatus("Faulted"),
 
     u: () => simulator.centralSystem.Authorize({idTag}),


### PR DESCRIPTION
[issue](https://my-ev-platform-84a2e5d88.sentry.io/issues/6508885585/?project=4508166344540160&query=is%3Aunresolved%20assigned%3A%5Bme%2Cmy_teams%2Ctommy.vandevelde%40energyvision.be%5D&referrer=issue-stream&sort=date&stream_index=2) related to session 104 1f00f8a4-85d9-653e-9e10-02b5aad4a865 included status updates suspendedEV and suspendedEVSE.

We weren't able to reproduce this, so we added these status notifications.