### PR TITLE
MOB-1069 charger simulator add schedule behaviour

### DIFF
--- a/src/ChargerSimulator.ts
+++ b/src/ChargerSimulator.ts
@@ -225,7 +225,6 @@ export class ChargerSimulator {
     ChangeAvailability: async(req) => {
       const isCharging = this.chargePoint.currentConnectorStatus === "Charging"
       if (req.type === "Inoperative" && (this.transactionId || isCharging)) {
-          this.chargePoint.currentConnectorStatus = req.type
           this.chargePoint.currentConnectorId = req.connectorId
           return {status: "Scheduled"}
       }

--- a/src/ChargerSimulator.ts
+++ b/src/ChargerSimulator.ts
@@ -194,7 +194,7 @@ export class ChargerSimulator {
       if (!req.connectorId) {
         req.connectorId = this.config.connectorId
       }
-      
+
       return {
         status: this.startTransaction(req, true) ? "Accepted" : "Rejected",
         // status: "Rejected",
@@ -223,6 +223,12 @@ export class ChargerSimulator {
     },
 
     ChangeAvailability: async(req) => {
+      const isCharging = this.chargePoint.currentConnectorStatus === "Charging"
+      if (req.type === "Inoperative" && (this.transactionId || isCharging)) {
+          this.chargePoint.currentConnectorStatus = req.type
+          this.chargePoint.currentConnectorId = req.connectorId
+          return {status: "Scheduled"}
+      }
       this.chargePoint.currentConnectorStatus = req.type
       this.chargePoint.currentConnectorId = req.connectorId
 


### PR DESCRIPTION
## Context of this PR

### Intro
Add scheduled behaviour in the charger simulator when a connector is inoperative while charging or when a transaction is active.

### References
Jira issue: MOB-1069

## What it should do

### What has been done and WHY?
- [x] When `req.type === "Inoperative"` and a transaction is active or the connector is charging, set `currentConnectorStatus` and `currentConnectorId` and return `Scheduled`.

### What does it look like?
N/A

## How to test

### Commands to run before testing it manually
```bash
make sim
```

### How to test it manually
- Trigger an `Inoperative` status while a transaction is active or the connector is charging.
- Verify the response status is `Scheduled`.
- Confirm the connector status and connector ID are updated.
